### PR TITLE
mcping

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,6 +24,7 @@ glob = "0.3"
 indicatif = "0.17.3"
 lazy_static = "1.4"
 log = "0.4"
+mcping = { git = "https://github.com/Scetch/mcping.git", features = ["tokio-runtime"] }
 regex = "1.7"
 reqwest = { version = "0.11", features = ["json", "stream"] }
 serde = { version = "1.0", features = ["derive"] }

--- a/src/main.rs
+++ b/src/main.rs
@@ -453,7 +453,7 @@ async fn get_or_set_mc_port(
                 return Err(e.into());
             }
         } else {
-            info!("Successfully set Minecraft port");
+            info!("Successfully set Minecraft port, please restart SSW to apply the changes.");
         }
     } else {
         // this just reports the port that the server is using, it doesn't check validity

--- a/src/proxy.rs
+++ b/src/proxy.rs
@@ -1,8 +1,9 @@
 use std::{
+    borrow::Cow,
     collections::{hash_map, HashMap},
     io,
     net::SocketAddr,
-    sync::{Arc, Mutex}, borrow::Cow,
+    sync::{Arc, Mutex},
 };
 
 use log::{debug, error, info, warn};
@@ -313,6 +314,8 @@ async fn connection_handler(mut client_stream: TcpStream, mc_port: u16) -> io::R
             return Ok(());
         }
     };
+    client_stream.set_nodelay(true)?;
+    server_stream.set_nodelay(true)?;
     // I'm upset I didn't find this sooner. This function solved almost all performance issues with
     // the proxy and passing TCP packets between the client and server.
     tokio::io::copy_bidirectional(&mut client_stream, &mut server_stream).await?;


### PR DESCRIPTION
This incorporates the mcping library to accurately check player counts on a Java server. This solves the issue where other software might open a connection to SSW that never closes, thus rendering the shutdown timer pointless.